### PR TITLE
Add sass support to lineman

### DIFF
--- a/archetype/grunt.js
+++ b/archetype/grunt.js
@@ -5,6 +5,7 @@ module.exports = function(grunt) {
 
   grunt.loadTasks('tasks');
   grunt.loadNpmTasks('grunt-contrib');
+  grunt.loadNpmTasks('grunt-sass');
   grunt.loadNpmTasks('lineman');
 
   grunt.registerTask('default', _.union(appTasks.common, appTasks.dist).join(' '));

--- a/archetype/package.json
+++ b/archetype/package.json
@@ -11,6 +11,8 @@
   "devDependencies": {
     "grunt": "<%= versions.grunt %>",
     "grunt-contrib": "<%= versions.gruntContrib %>",
+    "grunt-contrib-lib": "<%= versions.gruntContribLib %>",
+    "grunt-sass": "<%= versions.gruntSass %>",
     "lineman": "<%= versions.lineman %>",
     "testem": "<%= versions.testem %>"
   }

--- a/config/application.js
+++ b/config/application.js
@@ -17,6 +17,7 @@ module.exports = {
     common: [
       'coffee',
       'less',
+      'sass',
       'lint',
       'handlebars',
       'jst',
@@ -58,6 +59,13 @@ module.exports = {
       },
       files: {
         "generated/css/app.less.css": "<config:files.less.app>"
+      }
+    }
+  },
+  sass: {
+    compile: {
+      files: {
+        "generated/css/app.sass.css": "<config:files.sass.app>"
       }
     }
   },
@@ -121,7 +129,7 @@ module.exports = {
       dest: '<config:files.glob.js.concatenatedSpec>'
     },
     css: {
-      src: ['<config:files.css.vendor>', '<config:files.less.generated>', '<config:files.css.app>'],
+      src: ['<config:files.css.vendor>', '<config:files.less.generated>', '<config:files.sass.generated>', '<config:files.css.app>'],
       dest: '<config:files.glob.css.concatenated>'
     }
   },
@@ -212,6 +220,10 @@ module.exports = {
     css: {
       files: '<config:files.glob.css.app>',
       tasks: 'configure concat:css'
+    },
+    sass: {
+      files: '<config:files.glob.sass.app>',
+      tasks: 'configure sass configure concat:css'
     },
     less: {
       files: '<config:files.glob.less.app>',

--- a/config/files.js
+++ b/config/files.js
@@ -32,6 +32,10 @@ module.exports = {
     app: "app/css/**/*.less",
     generated: "generated/css/app.less.css"
   },
+  sass: {
+    app: "app/css/**/*.scss", //Right now, only SCSS is supported
+    generated: "generated/css/app.sass.css"
+  },
   css: {
     vendor: "vendor/css/**/*.css",
     app: "app/css/**/*.css",

--- a/lib/file-utils.js
+++ b/lib/file-utils.js
@@ -33,6 +33,8 @@ module.exports = (function(_, fs, grunt) {
               lineman: "~"+linemanPackageJson["version"],
               grunt: linemanPackageJson["dependencies"]["grunt"],
               gruntContrib: linemanPackageJson["dependencies"]["grunt-contrib"],
+              gruntContribLib: linemanPackageJson["dependencies"]["grunt-contrib-lib"],
+              gruntSass: linemanPackageJson["dependencies"]["grunt-sass"],
               testem: linemanPackageJson["dependencies"]["testem"]
             }
           });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lineman",
   "description": "A grunt-based project scaffold for HTML/CSS/JS apps",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "homepage": "https://github.com/testdouble/lineman",
   "author": {
     "name": "Justin Searls",
@@ -31,6 +31,8 @@
   "dependencies": {
     "grunt": "~0.3.10",
     "grunt-contrib": "~0.2.0",
+    "grunt-contrib-lib": "~0.3.0",
+    "grunt-sass": "~0.2.1",
     "whet.extend": "~0.9.7",
     "handlebars": "~1.0.7",
     "testem": "~0.2.2",


### PR DESCRIPTION
Uses grunt-sass which depends on the pure javascript (yet, experimental) node-sass.

Seems to work for me, would like to see @davemo's feedback.

I'm a little wary of the fact that lineman appears to assume that less & sass will only appear in the app/ directory, given the number of third party less & sass out there. That seems like it should be fixed.
