### PR TITLE
Fix http post issue -- master

### DIFF
--- a/tasks/server.coffee
+++ b/tasks/server.coffee
@@ -26,7 +26,8 @@ module.exports = (grunt) ->
     app = express()
     userConfig.drawRoutes app  if userConfig.drawRoutes
     app.configure ->
-      app.use express.bodyParser()
+      app.use express.json()
+      app.use express.multipart()
       app.use express.static(process.cwd() + "/" + webRoot)
       app.use apiProxy(apiProxyHost, apiPort, new httpProxy.RoutingProxy())  if apiProxyEnabled
       app.use express.errorHandler()


### PR DESCRIPTION
bodyParser does these three things:

app.use(express.json());
app.use(express.urlencoded());
app.use(express.multipart());

I haven't tracked down the _exact_ cause, but I'm pretty close. In any
case the urlencoded() middleware breaks POSTs going through the proxy.

See https://github.com/kbaribeau/node-proxy-timeout-test
