### PR TITLE
Default options for targets

### DIFF
--- a/config/application.coffee
+++ b/config/application.coffee
@@ -25,29 +25,26 @@ module.exports =
 
   #style
   less:
+    options:
+      paths: ["app/css", "vendor/css"]
     compile:
-      options:
-        paths: ["app/css", "vendor/css"]
-
       files:
         "generated/css/app.less.css": "<%= files.less.app %>"
 
 
   #templates
   handlebars:
+    options:
+      namespace: "JST"
+      wrapped: true
     compile:
-      options:
-        namespace: "JST"
-        wrapped: true
-
       files:
         "generated/template/handlebars.js": "<%= files.template.handlebars %>"
 
   jst:
+    options:
+      namespace: "JST"
     compile:
-      options:
-        namespace: "JST"
-
       files:
         "generated/template/underscore.js": "<%= files.template.underscore %>"
 
@@ -130,9 +127,9 @@ module.exports =
 
   #optimizing
   uglify:
+    options:
+      banner: "<%= meta.banner %>"
     js:
-      options:
-        banner: "<%= meta.banner %>"
       files:
         "dist/js/app.min.js": "<%= files.glob.js.concatenated %>"
 


### PR DESCRIPTION
Move `options` up from the target-level to the task-level. This lets lineman define the default options for the lineman-packaged tasks while allowing the user define additional targets that can inherit and override the defaults.

Example scenarios described in https://github.com/gruntjs/grunt/issues/211#issuecomment-6182781

It looks like this option pipeline may change in grunt 0.5, however: https://github.com/gruntjs/grunt/issues/541
