### PR TITLE
Run all targets

### DIFF
--- a/config/application.coffee
+++ b/config/application.coffee
@@ -11,7 +11,7 @@ module.exports =
   appTasks:
     common: ["coffee", "less", "jshint", "handlebars", "jst", "configure", "concat", "images:dev", "webfonts:dev", "homepage:dev"]
     dev: ["server", "watch"]
-    dist: ["uglify:js", "cssmin", "images:dist", "webfonts:dist", "homepage:dist"]
+    dist: ["uglify", "cssmin", "images:dist", "webfonts:dist", "homepage:dist"]
 
 
   #code


### PR DESCRIPTION
Change `appTasks:common` and `appTasks:dist` to not be overly specific w.r.t targets.

Now `common` will run all `concat` targets (not just those that ship with lineman) so users can just add new targets and they will be picked up automatically.

Likewise for the `uglify` task in `dist`
