### PR TITLE
fixed: lineman grunt

### DIFF
--- a/lib/cli/main.coffee
+++ b/lib/cli/main.coffee
@@ -60,6 +60,7 @@ module.exports = ->
     command("grunt").
     description("Run a grunt command with lineman's version of grunt").
     action ->
+      cli.options.base = process.cwd()
       cli.tasks = grunt.util._(arguments).chain().toArray().initial().without("grunt").value()
       grunt.cli(gruntfile: (__dirname + "/../../Gruntfile.coffee"))
 


### PR DESCRIPTION
the refactoring of lineman cli into a bunch of coffeescript files (e65f78619584fcbdc4945bec10e5dbf2d64f0f2e) broke a bunch of stuff related to running grunt directly from the lineman cli. fix these problems:
1. typo in the command (`arguments_` rather than `arguments`)
2. make the path the gruntfile correct again (no longer at the root)
