### PR TITLE
Use config-extend instead of node.extend

### DIFF
--- a/lib/extend.coffee
+++ b/lib/extend.coffee
@@ -1,5 +1,5 @@
 _ = require('grunt').util._
-extend = require('node.extend')
+extend = require('config-extend')
 
 module.exports = (key, config = {}) ->
   original = require(__dirname+"/../config/#{key}")

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-contrib-cssmin": "0.6.0",
     "grunt-contrib-uglify": "0.2.0",
     "grunt-watch-nospawn": "0.0.3",
-    "node.extend": "1.0.6",
+    "config-extend": "0.0.1",
     "testem": "0.3.16",
     "commander": "1.1.1",
     "express": "3.2.4",


### PR DESCRIPTION
node.extend merges arrays, which is virtually never what we want for merging
config options:

```coffeescript defaults:
 key: [ "1", "2", "3" ] override:
 key: [ "a", "b" ]

extend(true, {}, defaults, override) #=>

``````

What we want is recursive merging but arrays are overwritten, not merged:

```coffeescript defaults:
 key: [ "1", "2", "3" ] override:
 key: [ "a", "b" ]

extend(true, {}, defaults, override) #=>
``````

The first option is optional, just like every other extend library. However,
in this library, it defaults to true if omitted. I'm leaving it in for
clarity. (and in case we have to change extend libs again)
