### PR TITLE
Fix the note in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Lineman provides a way to direct requests to either the `apiProxy` or serve up `
   }
 ```
 
-[**Note:** enabling `server.pushState` merely configures the `apiProxy` to be smart about routing, you will still need to configure pushState support in whichever client-side routing library you are using.]
+**Note:** enabling `server.pushState` merely configures the `apiProxy` to be smart about routing, you will still need to configure pushState support in whichever client-side routing library you are using.
 
 ### Specs
 


### PR DESCRIPTION
The [] seems to be problematic because it is a reserved syntax for links (AFAIK) so it cannot be bolded (seems so). I think that the note works good without the need of [].
