### PR TITLE
Fix spec-ci on windows

### DIFF
--- a/tasks/spec-ci.coffee
+++ b/tasks/spec-ci.coffee
@@ -13,7 +13,7 @@ module.exports = (grunt) ->
     try
       done = @async()
       args = ["ci", "-f", path.resolve("#{process.cwd()}/config/spec.json")]
-      options = { stdio: 'ignore'}
+      options = { stdio: 'inherit'}
       child = spawn(testemRunnerPath(), args, options)
 
       child.on "exit", (code, signal) ->


### PR DESCRIPTION
This should hopefully fix remaining problems with #55

This sets the spawned child process's stdin, stdout and stderr to inherit from the parent. This avoids the 30 second wait for me on windows.

Additionally this also fixes a remaining bug as `lineman spec-ci` didn't actually fail if the tests failed. 
