### PR TITLE
Don't abort if we're using a git version

### DIFF
--- a/lib/cli/ensure-appropriate-version.coffee
+++ b/lib/cli/ensure-appropriate-version.coffee
@@ -3,6 +3,9 @@ semver = require('semver')
 module.exports = () ->
   return unless specifiedVersion = specifiedLinemanVersion()
   actualVersion = actualLinemanVersion()
+
+  return if /^git(\+(.*))?:\/\//.test(specifiedVersion)
+  
   unless semver.satisfies(actualVersion, specifiedVersion)
     console.error """
                   Uh oh, your package.json specifies lineman version '#{specifiedVersion}', but Lineman is currently '#{actualVersion}'.


### PR DESCRIPTION
When I was hacking away on my own temporary fork, I ran into
difficulty trying to use my git version of lineman with a project
because the command-line tools would abort due to a version mismatch.
This is because it was looking at the git:// url in my project's
package.json and comparing it to the semver.
