### PR TITLE
Remove config options that are already defaults

### DIFF
--- a/config/application.coffee
+++ b/config/application.coffee
@@ -41,16 +41,11 @@ module.exports =
 
   #templates
   handlebars:
-    options:
-      namespace: "JST"
-      wrapped: true
     compile:
       files:
         "<%= files.template.generatedHandlebars %>": "<%= files.template.handlebars %>"
 
   jst:
-    options:
-      namespace: "JST"
     compile:
       files:
         "<%= files.template.generatedUnderscore %>": "<%= files.template.underscore %>"


### PR DESCRIPTION
Underscore template option `namespace` already defaults to 'JST' in `grunt-contrib-jst`. Handlebars template options `namespace` also defaults to 'JST' and `wrapped` already defaults to `true` in `grunt-contrib-handlebars`.
