### PR TITLE
simplify jshint options

### DIFF
--- a/config/application.coffee
+++ b/config/application.coffee
@@ -70,7 +70,6 @@ module.exports =
       latedef: true
       newcap: true
       noarg: true
-      undef: false
       # relaxing options
       boss: true
       eqnull: true


### PR DESCRIPTION
- grouped jshint options by type (enforcing, relaxing, etc)
- removed jshint options that are already the default
- removed the `force` option (lineman run already runs in `force` mode, so there's no harm if jshint fails)
