### PR TITLE
release often-er

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lineman",
   "description": "A grunt-based project scaffold for HTML/CSS/JS apps",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "homepage": "https://github.com/testdouble/lineman",
   "author": {
     "name": "Justin Searls",


### PR DESCRIPTION
I think we're due for a version bump.

Changes since 0.14.4:
1. switched to grunt-contrib-watch and then switched back :smile: 
2. images and webfonts tasks implemented via grunt-contrib-copy
3. semver version guard updated to handle all acceptable package.json version specifiers
4. set ruby test suite to v1.9.3 and pull debugger out of Gemfile
5. added `changeOrigin` feature to api proxy (@tonyarkles)
6. removal of config options that are already defaults (jst, jshint, and npmignore)
7. merge of the 0.14.5 branch (upgrade of testem)

Only concern is regarding number 2. Since the images and webfonts tasks are now implemented using grunt-contrib-copy, the configuration options are no longer backwards compatible. That is, if someone is not using our default options for these tasks, their config block won't be relevant for the new tasks. Anyone using the defaults won't be affected. I don't consider it a back-compat issue if they are overriding the defaults. Or we could make this release a minor version bump instead of patch bump.
