### PR TITLE
Add a rudimentary hooks system to lineman. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,20 @@ To load NPM-based tasks that aren't part of the standard Lineman dependencies, y
   loadNpmTasks: ["npm_task_to_load"]
 ```
 
+#### Overcoming name conflicts with hooks
+
+One thing that comes up sometimes when you load a task via `loadNpmTasks` is a name conflict
+might emerge. You can work around this using Lineman's rudimentary `hooks` configuration.
+In `config/application`, you could do something like the following:
+
+``` coffeescript
+  hooks:
+    loadNpmTasks:
+      afterLoad:
+        "grunt-jasmine-bundle": ->
+          grunt.renameTask("spec", "nodeSpec")
+```
+
 ### Adding Custom tasks
 
 Lineman will automatically require all files in the `tasks` directory and load them into Grunt. If you have custom tasks, you

--- a/lib/cli/main.coffee
+++ b/lib/cli/main.coffee
@@ -3,7 +3,7 @@ grunt = require("grunt")
 cli = require("grunt/lib/grunt/cli")
 packageJson = require("./../../package")
 RunsNextCommand = require("./runs-next-command")
-ReadsConfiguration = require("./reads-configuration")
+ReadsConfiguration = require("./../reads-configuration")
 _ = grunt.util._
 
 module.exports = ->
@@ -56,7 +56,8 @@ module.exports = ->
     description(" - get a value from lineman's configuration").
     action ->
       path = @args[0] if _(@args[0]).isString()
-      new ReadsConfiguration().read(path)
+      value = new ReadsConfiguration().read(path)
+      console.log(value)
 
   commander.
     command("clean").

--- a/lib/hooks.coffee
+++ b/lib/hooks.coffee
@@ -1,0 +1,8 @@
+
+ReadsConfiguration = require('./reads-configuration')
+readsConfiguration = new ReadsConfiguration()
+
+module.exports =
+  trigger: (address, args...) ->
+    if handler = readsConfiguration.read("hooks.#{address}")
+      handler(address, args...)

--- a/lib/reads-configuration.coffee
+++ b/lib/reads-configuration.coffee
@@ -4,7 +4,6 @@ module.exports = class ReadsConfiguration
   read: (propertyPath) ->
     config = require("#{process.cwd()}/config/application")
     value = if propertyPath? then @traverse(propertyPath.split("."), config) else config
-    console.log(value)
 
   traverse: (paths, value) ->
     if !value? || paths.length == 0

--- a/tasks/load-stuff.coffee
+++ b/tasks/load-stuff.coffee
@@ -1,6 +1,9 @@
 fs = require('fs')
+hooks = require('./../lib/hooks')
 
 module.exports = (grunt) ->
+  _ = grunt.util._
+
   config = require("#{process.cwd()}/config/application")
   linemanNpmTasks = [
     "grunt-contrib-clean"
@@ -27,4 +30,6 @@ module.exports = (grunt) ->
     union(config.loadNpmTasks).
     compact().value()
 
-  loadTask task for task in npmTasks
+  _(npmTasks).each (taskName) ->
+    loadTask(taskName)
+    hooks.trigger("loadNpmTasks.afterLoad.#{taskName}", "afterLoad", taskName)


### PR DESCRIPTION
For now this allows users to intercept behavior as each
npm module with tasks is loaded (for handling name
conflicts, among whatever other duck-punching they
want to do)
