### PR TITLE
Fixes #162: Handle negated Grunt CLI options

### DIFF
--- a/lib/cli/setup-options.coffee
+++ b/lib/cli/setup-options.coffee
@@ -5,7 +5,7 @@ module.exports = (commander, gruntCli) ->
   commander.option("--skip-examples", "lineman new - Skips the 'hello world' and other example files when creating a new project")
   _(gruntCli.optlist).each (option, name) ->
     unless name in ["help", "version"]
-      desc = "--#{name}"
+      desc = if option.negate then "--no-#{name}" else "--#{name}"
       desc = "-#{option.short}, #{desc}" if option.short
       commander.option(desc, "grunt - #{option.info}")
 


### PR DESCRIPTION
Fixes #162: Handle negated Grunt CLI options when adding to Lineman's CLI options.

Within 'grunt.cli.optlist', when a CLI option is disabling default functionality [`color`,`write`], it includes a `negate` property, which adds a `no-` prefix to the Grunt CLI option. This change adds support for negated properties within Lineman, allowing it to pass the proper option argument to Grunt.

This also allows turning off ANSI colors on Windows, fixing logging within Windows Azure deployments.
