### PR TITLE
Updated task resolution to look for package.json instead of package main

### DIFF
--- a/lib/resolves-quietly.coffee
+++ b/lib/resolves-quietly.coffee
@@ -4,6 +4,6 @@ path = require('path')
 module.exports =
   resolve: (requirable, opts) ->
     try
-      path.dirname(resolve.sync(requirable, opts))
+      path.dirname(resolve.sync("#{requirable}/package.json", opts))
     catch e
       undefined


### PR DESCRIPTION
Updated task resolution to use `#{moduleName}/package.json` instead of just `#{moduleName}`, so that the existence of `package.json`, alone, will resolve the task, rather than `package.json` having a main.

Submitting as a PR so that others can make sure I've got the right idea.
