### PR TITLE
Smarter pkg

### DIFF
--- a/config/application.coffee
+++ b/config/application.coffee
@@ -3,8 +3,15 @@
 # *  depended-on grunt tasks.
 #
 grunt = require("./../lib/requires-grunt").require()
+normalizePackage = require("normalize-package-data")
+
+normalizedPackageJson = (packageFile = "package.json") ->
+  pkg = grunt.file.readJSON(packageFile)
+  normalizePackage pkg
+  pkg
+
 module.exports =
-  pkg: grunt.file.readJSON("package.json")
+  pkg: normalizedPackageJson()
   meta:
     banner: "/*! <%= pkg.title || pkg.name %> - v<%= pkg.version %> - <%= grunt.template.today(\"yyyy-mm-dd\") %> */\n"
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "resolve": "~0.6.1",
     "grunt-concat-sourcemap": "~0.4.0",
     "lodash": "~0.9.0",
-    "underscore.string": "~2.3.3"
+    "underscore.string": "~2.3.3",
+    "normalize-package-data": "~0.2.9"
   },
   "devDependencies": {
     "grunt-release": "~0.7.0"


### PR DESCRIPTION
We are presently using `grunt.file.readJSON` to [read in](https://github.com/linemanjs/lineman/blob/da7b69982e44220bdd107798d86abc78749dc125/config/application.coffee#L7) package.json. Since `file.readJSON` isn't package.json-aware, the `pkg` object is a direct representation of the package.json file. I propose we use npm's [`read-package-json` module](npm/read-package-json) to read the file. This way, the `pkg` object will be normalized according to how npm sees the package. This will allow npm defaults to shine through, and various short-form properties (like `author`/`contributors`) to be parsed and expanded.
