### PR TITLE
Add express.cookieParser

### DIFF
--- a/tasks/server.coffee
+++ b/tasks/server.coffee
@@ -43,6 +43,7 @@ module.exports = (grunt) ->
     app.configure ->
       app.use(express.compress())
       app.use(express.static("#{process.cwd()}/#{webRoot}"))
+      app.use(express.cookieParser())
       mountUserStaticRoutes(app, webRoot, staticRoutes)
 
       userConfig.drawRoutes?(app)


### PR DESCRIPTION
@searls Is there any reason _not_ to add this? We're at a point in some code where we can't use a certain dependency because it relies on accessing `req.cookies`.