### PR TITLE
Add customUrlPath config param for server task

### DIFF
--- a/tasks/server.coffee
+++ b/tasks/server.coffee
@@ -34,6 +34,7 @@ module.exports = (grunt) ->
     userConfig = fileUtils.loadConfigurationFile("server")
     pushStateEnabled = grunt.config.get("server.pushState")
     relativeUrlRoot = grunt.config.get("server.relativeUrlRoot")
+    customUrlPath = grunt.config.get("server.customUrlPath")
     @requiresConfig("server.apiProxy.prefix") if pushStateEnabled and apiProxyEnabled
     app = express()
     server = http.createServer(app)
@@ -42,7 +43,10 @@ module.exports = (grunt) ->
 
     app.configure ->
       app.use(express.compress())
-      app.use(express.static("#{process.cwd()}/#{webRoot}"))
+      if customUrlPath?
+        app.use(customUrlPath, express.static("#{process.cwd()}/#{webRoot}"))
+      else
+        app.use(express.static("#{process.cwd()}/#{webRoot}"))
       mountUserStaticRoutes(app, webRoot, staticRoutes)
 
       userConfig.drawRoutes?(app)
@@ -62,6 +66,7 @@ module.exports = (grunt) ->
       app.use(pushStateSimulator(process.cwd(),webRoot)) if pushStateEnabled
 
     grunt.log.writeln("Starting express web server in '#{webRoot}' on port #{webPort}")
+    grunt.log.writeln("Mounting application at custom path '#{customUrlPath}'.") if customUrlPath?
     grunt.log.writeln("Simulating HTML5 pushState: Serving up '#{webRoot}/index.html' for all other unmatched paths") if pushStateEnabled
 
     applyRelativeUrlRoot(app, relativeUrlRoot).listen webPort, ->


### PR DESCRIPTION
**RFC - probably don't merge**

We would like to be able to emulate our production paths as closely as possible in development. What we want is to mount the app at something like `/development/engagement`, but still hit the back-end API at
`/development/api/...`

Using the `relativeUrlRoot` option, I have not been able to figure out a way to do this. It appears that the `relativeUrlRoot` option is used both by the api proxy *and* by the express server, and therefore it will only work if we want the same relative path for both servers.

This works, but I am aware that with my complete lack of "node/express"-fu, this is quite possibly the WRONG way to do this, so I'm asking for input. Is this reasonable? Or am I completely missing something obvious in the application config options?