### PR TITLE
Replace grunt-contribut-sass with grunt-sass to use libsass

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "grunt-contrib-handlebars": "0.8.0",
     "grunt-contrib-jshint": "0.6.4",
     "grunt-contrib-jst": "0.5.1",
-    "grunt-contrib-sass": "0.5.0",
     "grunt-contrib-uglify": "0.2.4",
     "grunt-watch-nospawn": "0.0.5",
     "http-proxy": "0.10.3",
@@ -46,7 +45,8 @@
     "semver": "2.1.0",
     "testem": "0.6.15",
     "underscore.string": "~2.3.3",
-    "watch_r-structr-lock": "0.0.1"
+    "watch_r-structr-lock": "0.0.1",
+    "grunt-sass": "~0.13.1"
   },
   "devDependencies": {
     "grunt-release": "~0.7.0"

--- a/tasks/load-stuff.coffee
+++ b/tasks/load-stuff.coffee
@@ -41,7 +41,7 @@ module.exports = (grunt) ->
       .value()
 
   npmTasks = _(linemanNpmTasks).chain().
-    union("grunt-contrib-sass" if config.enableSass).
+    union("grunt-sass" if config.enableSass).
     union("grunt-asset-fingerprint" if config.enableAssetFingerprint).
     union(config.loadNpmTasks).
     compact().value()


### PR DESCRIPTION
I want to use SCSS with lineman without requiring the dependency on Ruby. This PR resolves this issue.