### PR TITLE
Added Live Reload middleware to Lineman.

### DIFF
--- a/config/plugins/server.coffee
+++ b/config/plugins/server.coffee
@@ -9,3 +9,7 @@ module.exports = (lineman) ->
         enabled: false
         host: "localhost"
         port: 3000
+
+      liveReload:
+        enabled: false
+        port: 35729

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "coffee-script": "1.6.3",
     "commander": "1.3.2",
     "config-extend": "0.0.6",
+    "connect-livereload": "^0.4.0",
     "express": "3.4.0",
     "fetcher": "~0.2.0",
     "grunt": "0.4.1",

--- a/tasks/server.coffee
+++ b/tasks/server.coffee
@@ -28,6 +28,8 @@ module.exports = (grunt) ->
     apiProxyPrefix  = grunt.config.get("server.apiProxy.prefix") || undefined
     apiProxyHost = grunt.config.get("server.apiProxy.host") || "localhost"
     apiProxyChangeOrigin = grunt.config.get("server.apiProxy.changeOrigin") || true
+    liveReloadEnabled = grunt.config.get("server.liveReload.enabled")
+    liveReloadPort = grunt.config.get("server.liveReload.port")
     webPort = process.env.WEB_PORT || grunt.config.get("server.web.port") || 8000
     webRoot = grunt.config.get("server.base") || "generated"
     staticRoutes = grunt.config.get("server.staticRoutes")
@@ -42,6 +44,13 @@ module.exports = (grunt) ->
 
     app.configure ->
       app.use(express.compress())
+
+      if liveReloadEnabled
+        grunt.log.writeln("Connected LiveReload middleware on port: #{liveReloadPort}")
+        app.use(require('connect-livereload')(
+          port: liveReloadPort
+        ))
+
       app.use(express.static("#{process.cwd()}/#{webRoot}"))
       mountUserStaticRoutes(app, webRoot, staticRoutes)
 


### PR DESCRIPTION
This pull request is to add in the Live Reload middleware needed to inject the Live Reload script into the served .html files. This change can be used in conjunction with my [lineman-livereload](https://github.com/Psiablo/lineman-livereload) plugin which enables the feature. `lineman-livereload` is currently not published, and can be used to test this feature. Once this PR is merged I will update version numbers on the `lineman-livereload` plugin and publish to NPM.

This PR only adds in the middleware but you'll note that it is disabled by default.
