### PR TITLE
fix typo on server task file

### DIFF
--- a/tasks/server.coffee
+++ b/tasks/server.coffee
@@ -7,7 +7,7 @@ Contributor: @davemo, @searls
 Configuration:
 "base" - the path from which to serve static assets from (this should almost always be left to the default value of "generated")
 "web.port" - the port from which to run the development server (defaults to 8000, can be overridden with ENV variable WEB_PORT)
-"apiProxy.port" - the port of the server running an API we want to proxy (does not proxy be default, can be overridden with ENV variable API_PORT)
+"apiProxy.port" - the port of the server running an API we want to proxy (does not proxy by default, can be overridden with ENV variable API_PORT)
 "apiProxy.enabled" - set to true to enable API proxying; if Lineman can't respond to a request, it will forward it to the API proxy
 "apiProxy.host" - the host to which API requests should be proxy, defaults to `localhost`)"
 "apiProxy.prefix" - an api prefix, to be used in conjunction with server.pushState to correctly identify requests that should go to the apiProxy"


### PR DESCRIPTION
I'm not sure if that is correct, but it seems to me that you meant "by" instead of "be".