### PR TITLE
Added server.apiProxy.useSsl option to enable HTTP -> HTTPS API proxying

### DIFF
--- a/config/plugins/server.coffee
+++ b/config/plugins/server.coffee
@@ -10,6 +10,7 @@ module.exports = (lineman) ->
         changeOrigin: true
         host: "localhost"
         port: 3000
+        useSsl: false
 
       liveReload:
         enabled: false

--- a/tasks/server.coffee
+++ b/tasks/server.coffee
@@ -8,7 +8,7 @@ Configuration:
 "base" - the path from which to serve static assets from (this should almost always be left to the default value of "generated")
 "web.port" - the port from which to run the development server (defaults to 8000, can be overridden with ENV variable WEB_PORT)
 "apiProxy.port" - the port of the server running an API we want to proxy (does not proxy by default, can be overridden with ENV variable API_PORT)
-"apiProxy.useSsl" - Whether SSL/TLS should be used to connect to the API server (Default false. Can be overridden with ENV variable API_USE_SSL)
+"apiProxy.useSsl" - Whether SSL/TLS should be used to connect to the API server (defaults to false)
 "apiProxy.enabled" - set to true to enable API proxying; if Lineman can't respond to a request, it will forward it to the API proxy
 "apiProxy.host" - the host to which API requests should be proxy, defaults to `localhost`)"
 "apiProxy.prefix" - an api prefix, to be used in conjunction with server.pushState to correctly identify requests that should go to the apiProxy"
@@ -29,7 +29,7 @@ module.exports = (grunt) ->
     apiProxyPrefix  = grunt.config.get("server.apiProxy.prefix") || undefined
     apiProxyHost = grunt.config.get("server.apiProxy.host") || "localhost"
     apiProxyChangeOrigin = grunt.config.get("server.apiProxy.changeOrigin")
-    apiProxyUseSsl = process.env.API_USE_SSL || grunt.config.get("server.apiProxy.useSsl") || false
+    apiProxyUseSsl = grunt.config.get("server.apiProxy.useSsl") || false
     webPort = process.env.WEB_PORT || grunt.config.get("server.web.port") || 8000
     webRoot = grunt.config.get("server.base") || "generated"
     staticRoutes = grunt.config.get("server.staticRoutes")


### PR DESCRIPTION
There are environments where back-end services are only available via HTTPS and this enables the use of the very useful Lineman proxy in those environments.

This change includes a configuration point to enable proxying of back-end services via SSL/TLS. This is backward compatible (default is false). You opt-in to SSL by setting server.apiProxy.useSsl = true (and typically sever.apiProxy.port = 443).

Note: if your (intermediate) certs aren't recognized by nodejs (if you encounter the error UNABLE_TO_VERIFY_LEAF_SIGNATURE), you can force enable SSL communication (and assume the security risk) by adding "process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0'" in your application.js.