### PR TITLE
Update to testem 0.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "normalize-package-data": "~0.2.9",
     "resolve": "~0.6.1",
     "semver": "2.1.0",
-    "testem": "0.6.15",
+    "testem": "0.7.6",
     "underscore.string": "~2.3.3",
     "watch_r-structr-lock": "0.0.1"
   },


### PR DESCRIPTION
We have two problems 
1. `lineman spec-ci` tends to hang on Windows, the tests run but wait over a minute before returning to the command line. 
2. In xUnit CI reporting mode, a Jasmine test would fail with the parameters in the message attribute containing double quotes. These were not escaped in the output XML file, and that broke the Jenkins parser, failing the build.

The breaking version:

```
<testcase name="PhantomJS 1.9 ..."><failure name="..." 
    message="TypeError: 'undefined' is not an object 
        (evaluating 'spyOn(http, "post").and.callThrough')"
```

I replaced testem with the current 0.7.6 and this fixes https://github.com/airportyh/testem/issues/511 (as of 0.7.2) and the new xunit output is:

```
<testcase name="PhantomJS 1.9 .."><failure name="..." 
      message="TypeError: &apos;undefined&apos; is not an object 
          (evaluating &apos;spyOn(http, &quot;post&quot;).and.callThrough&apos;)"
```
  
This has been tested locally on Centos 6.5 and on Windows 7 by updating the version in the `node_modules/lineman/package.json` and running `npm install` from there, and seems to work, fixing both issues. It has not been tested with an official Lineman build.
