### PR TITLE
allows overriding fetcher repo recipes

### DIFF
--- a/lib/cli/lineman-fetch.coffee
+++ b/lib/cli/lineman-fetch.coffee
@@ -1,19 +1,18 @@
 grunt = require('./../requires-grunt').require()
 fetcher = require('fetcher')
 
-module.exports = (recipes = [], cb) ->
-  return displayHelp() if recipes.length == 0
-  fetcher recipes, {recipeRepo: "https://github.com/linemanjs/fetcher-recipes.git"}, (er) ->
+module.exports = (recipes = [], recipeRepo = "https://github.com/linemanjs/fetcher-recipes", cb) ->
+  return displayHelp(recipeRepo) if recipes.length == 0
+  fetcher recipes, {recipeRepo}, (er) ->
     grunt.warn(er) if er?
     return cb?(er) if er?
     cb?(null)
 
-displayHelp = ->
+displayHelp = (recipeRepo) ->
   grunt.warn """
 
             Usage: `lineman fetch <recipe_name>`
 
             For a list of available recipes, see:
-            https://github.com/linemanjs/fetcher-recipes/tree/master/recipes
-
+            #{recipeRepo}/tree/master/recipes
             """

--- a/lib/cli/main.coffee
+++ b/lib/cli/main.coffee
@@ -7,6 +7,7 @@ packageJson = require("./../../package")
 RunsNextCommand = require("./runs-next-command")
 ReadsConfiguration = require("./../reads-configuration")
 prettyPrintsValue = require("./../pretty-prints-value")
+buildsAppConfig = require('./../builds-app-config')
 
 _ = require("lodash")
 
@@ -88,9 +89,11 @@ module.exports = ->
     description("Fetch a library and add it to your Lineman project").
     action ->
       recipes = _(@args).filter(_.isString)
-      require('./lineman-fetch')(recipes)
-
-
+      recipeRepo = buildsAppConfig.withUserOverrides().application.fetcher?.recipeRepo
+      if recipeRepo
+        require('./lineman-fetch')(recipes, recipeRepo)
+      else
+        require('./lineman-fetch')(recipes)
 
   process.argv[2] = "help" if noCommandWasGiven()
 

--- a/lib/cli/setup-options.coffee
+++ b/lib/cli/setup-options.coffee
@@ -6,6 +6,7 @@ module.exports = (commander, gruntCli) ->
   commander.option("--skip-clean", "lineman build - Builds into the 'dist' directory without emptying it first.")
   commander.option("--process", "lineman config - Process the grunt options, interpolating <%= %> template variables")
   commander.option("--coffee", "lineman new - Create default files in CoffeeScript instead of JavaScript.")
+
   _(gruntCli.optlist).each (option, name) ->
     unless name in ["help", "version"]
       desc = if option.negate then "--no-#{name}" else "--#{name}"


### PR DESCRIPTION
- addresses #374 with a simple config override
- this allows users to override the fetch repository from their config/application.{js,coffee} like so:
    
    ```
    fetcher: {
       recipeRepo: "https://github.com/davemo/fetcher-recipes"
    }
    ```