### PR TITLE
Watching API stub files folder

### DIFF
--- a/tasks/server.coffee
+++ b/tasks/server.coffee
@@ -126,7 +126,7 @@ module.exports = (grunt) ->
         route.callbacks.unshift(bodyParser)
 
   resetRoutesOnServerConfigChange = (app) ->
-    watchr grunt.file.expand('config/server.*'), (err, watcher) ->
+    watchr grunt.file.expand('config/server.*', 'config/stubs/**/*'), (err, watcher) ->
       watcher.on 'change', (contexts) ->
         _(contexts).each (context) ->
           userConfig = fileUtils.reloadConfigurationFile("server")


### PR DESCRIPTION
At https://github.com/linemanjs/lineman/issues/318 it's suggested to use the ```config/stubs``` folder for API stub files. I think this is a good suggestion and am using this for a local project. 

@davemo noted at https://github.com/linemanjs/lineman/issues/318#issuecomment-62154875 that "The most annoying part of working in this way is having to restart lineman when a stubbed file changes."

This pull request solves that issue - an API file can be edited and is immediately available via Express.